### PR TITLE
Fixing possible IllegalArgumentException: can only use lower 8 bits for requestCode

### DIFF
--- a/let-runtime/src/main/java/com/canelmas/let/RuntimePermissionRequest.java
+++ b/let-runtime/src/main/java/com/canelmas/let/RuntimePermissionRequest.java
@@ -121,7 +121,7 @@ public final class RuntimePermissionRequest {
 
             Logger.log("<<< Making permission request");
 
-            final int requestCode = PERMISSIONS_REQUEST_CODE.getAndIncrement();
+            final int requestCode = PERMISSIONS_REQUEST_CODE.getAndIncrement() & 0xff;
 
             DelayedTasks.add(new DelayedTasks.Task(permissionsToAsk, requestCode, joinPoint));
 


### PR DESCRIPTION
Even if that's unlikely to happen, `requestPermissions()` only accept values from 0 to 255. This is a quick fix to avoid any IllegalArgumentException.
